### PR TITLE
Remove initial loadign of relation records in form by ajax. 

### DIFF
--- a/crud/default/views/_form.php
+++ b/crud/default/views/_form.php
@@ -53,7 +53,9 @@ foreach ($relations as $name => $rel) {
 foreach ($relations as $name => $rel) {
     $relID = Inflector::camel2id($rel[1]);
     if ($rel[2] && isset($rel[3]) && !in_array($name, $generator->skippedRelations)) {
-        echo "    <div class=\"form-group\" id=\"add-$relID\"></div>\n\n";
+        echo "    <div class=\"form-group\" id=\"add-$relID\">\n"
+            . "        <?= \$this->render('_form".$rel[1]."', ['row'=>\yii\helpers\ArrayHelper::toArray(\$model->$name)]); ?>\n"
+            . "    </div>\n\n";
     }
 }
 ?>

--- a/crud/default/views/_script.php
+++ b/crud/default/views/_script.php
@@ -4,17 +4,6 @@ use yii\helpers\Url;
 ?>\n"
 ?>
 <script>
-    $(function () {
-        var data = <?= "<?= \$value ?>" ?>;
-        $.ajax({
-            type: 'POST',
-            url: '<?= "<?php echo Url::to(['add-'.\$relID]); ?>"; ?>',
-            data: {'<?= "<?= \$class?>"?>' : data, action : 'load', isNewRecord : <?= "<?= \$isNewRecord ?>" ?>},
-            success: function (data) {
-                $('#add-<?= "<?= \$relID?>"; ?>').html(data);
-            }
-        });
-    });
     function addRow<?= "<?= \$class ?>" ?>() {
         var data = $('#add-<?= "<?= \$relID?>"; ?> :input').serializeArray();
         data.push({name: 'action', value : 'add'});


### PR DESCRIPTION
Hi, had some issues with loading related data by ajax. If someone is quick enought, he can save form before related data are loaded = lost of related data.

Side effect - better debug, because exceptions in related form are in main request.
