### PR TITLE
Re-indexing $row for Tabular Form

### DIFF
--- a/crud/default/controller.php
+++ b/crud/default/controller.php
@@ -302,6 +302,9 @@ if (count($pks) === 1) {
     {
         if (Yii::$app->request->isAjax) {
             $row = Yii::$app->request->post('<?= $rel[1] ?>');
+            if (!empty($row)) {
+                $row = array_values($row);
+            }
             if((Yii::$app->request->post('isNewRecord') && Yii::$app->request->post('_action') == 'load' && empty($row)) || Yii::$app->request->post('_action') == 'add')
                 $row[] = [];
             return $this->renderAjax('_form<?= $rel[1] ?>', ['row' => $row]);


### PR DESCRIPTION
When removing an entry in Tabular Form (via JS) the $row array will not be re-indexed, resulting in missing indexes i.e. [1] => 'London', [3] => 'Paris', [4] => 'New York'.  
When adding entries in this state Tabular Form will not add entries at the end of the list, but add entries in the middle of the list and eventually overwrite existing entries. Strange behaviour, I know. 
So it is necessary to re-index $row after each removal. We cannot know if entries where removed by JS at this point in the controller, so $row gets re-indexed every time before adding another entry.
Works perfect. Tested it in my code.