### PR TITLE
Update to templates

### DIFF
--- a/crud/default/controller.php
+++ b/crud/default/controller.php
@@ -123,7 +123,7 @@ class <?= $controllerClass ?> extends <?= StringHelper::basename($generator->bas
 <?php endif; ?>
 <?php endforeach; ?>
         return $this->render('view', [
-            'model' => $this->findModel(<?= $actionParams ?>),
+            'model' => $model,
 <?php foreach ($relations as $name => $rel): ?>
 <?php if ($rel[2] && isset($rel[3]) && !in_array($name, $generator->skippedRelations)): ?>
             'provider<?= $rel[1]?>' => $provider<?= $rel[1]?>,

--- a/model/default/model-extended.php
+++ b/model/default/model-extended.php
@@ -31,7 +31,10 @@ class <?= $className ?> extends Base<?= $className . "\n" ?>
     public function rules()
     {
         return array_replace_recursive(parent::rules(),
-	    [<?= "\n            " . implode(",\n            ", $rules) . "\n        " ?>]);
+	        [
+                //Add your custom rules here
+            ]
+        );
     }
 	
 <?php if ($generator->generateAttributeHints): ?>


### PR DESCRIPTION
I have updated templates for model and crud controller.
- Extended model had a list of rules from the base model. Rules set was already being merged with the base and it was a cluttered version.
- Controller was calling findModel twice one at the beginning of the function and second when returning. It now uses the fetched model beforehand.

I'm not sure if those two things were deliberate, but I thought it might be better to modify them.