### PR TITLE
Apply Schema::TYPE_TINYINT to Model Rules

### DIFF
--- a/model/Generator.php
+++ b/model/Generator.php
@@ -440,7 +440,8 @@ class Generator extends BaseGenerator {
             switch ($column->type) {
                 case Schema::TYPE_SMALLINT:
                 case Schema::TYPE_INTEGER:
-                case Schema::TYPE_BIGINT:
+				case Schema::TYPE_BIGINT:
+				case Schema::TYPE_TINYINT:
                     $types['integer'][] = $column->name;
                     break;
                 case Schema::TYPE_BOOLEAN:


### PR DESCRIPTION
When have to apply TINYINT to generateRules , otherwise it will be handled as
a string.